### PR TITLE
Switch default AI provider to OpenAI and improve mobile UX

### DIFF
--- a/api/ai.js
+++ b/api/ai.js
@@ -1,173 +1,187 @@
-﻿export default async function handler(req, res) {
-  if (req.method !== "POST") {
-    return res.status(405).json({ items: [], message: "POST only" });
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'POST only' });
   }
 
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    return res.status(500).json({ items: [], message: "OPENAI_API_KEY is missing" });
+  const body = typeof req.body === 'string' ? safeJson(req.body) : req.body;
+  if (!body || typeof body !== 'object') {
+    return res.status(400).json({ error: 'Invalid body' });
   }
 
-  const body = typeof req.body === "string" ? safeJsonParse(req.body) : req.body;
-  const mode = body && body.mode;
-  const payload = (body && body.payload) || {};
+  const mode = body.mode;
+  const payload = body.payload;
 
-  if (!["breakdown", "mandalart", "top3"].includes(mode)) {
-    return res.status(400).json({ items: [], message: "Invalid mode" });
+  if (!['chat', 'suggest'].includes(mode)) {
+    return res.status(400).json({ error: 'Invalid mode' });
   }
+
+  if (!payload || typeof payload !== 'object') {
+    return res.status(400).json({ error: 'Missing payload' });
+  }
+
+  const validated = validatePayload(payload);
+  if (!validated.ok) {
+    return res.status(400).json({ error: validated.error });
+  }
+
+  const provider = (process.env.AI_PROVIDER || 'openai').toLowerCase();
 
   try {
-    const { systemPrompt, userPrompt } = buildPrompts(mode, payload);
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 25000);
+    const reply = provider === 'claude'
+      ? await callClaude(mode, validated.value)
+      : await callOpenAI(mode, validated.value);
 
-    const openaiRes = await fetch("https://api.openai.com/v1/responses", {
-      method: "POST",
-      signal: controller.signal,
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`
-      },
-      body: JSON.stringify({
-        model: process.env.OPENAI_MODEL || "gpt-4.1-mini",
-        temperature: 0.2,
-        max_output_tokens: 1500,
-        input: [
-          { role: "system", content: [{ type: "input_text", text: systemPrompt }] },
-          { role: "user", content: [{ type: "input_text", text: userPrompt }] }
-        ]
-      })
-    });
-
-    clearTimeout(timeout);
-
-    if (!openaiRes.ok) {
-      const errText = await openaiRes.text();
-      return res.status(openaiRes.status).json({ items: [], message: `OpenAI error: ${errText.slice(0, 300)}` });
-    }
-
-    const openaiJson = await openaiRes.json();
-    const rawText = readOutputText(openaiJson);
-    const parsed = parseModelJson(rawText);
-
-    if (!parsed || !Array.isArray(parsed.items)) {
-      return res.status(502).json({ items: [], message: "Model returned invalid JSON shape" });
-    }
-
-    const items = parsed.items
-      .filter((item) => item && typeof item.text === "string" && item.text.trim())
-      .map((item) => ({
-        text: String(item.text).trim(),
-        dueDate: normalizeDate(item.dueDate),
-        priority: normalizePriority(item.priority),
-        category: normalizeCategory(item.category),
-        mandalartCell: normalizeCell(item.mandalartCell)
-      }));
-
-    const message = typeof parsed.message === "string" ? parsed.message : "AI 추천 결과입니다.";
-    return res.status(200).json({ items, message });
-  } catch (error) {
-    const msg = error && error.name === "AbortError" ? "AI request timeout" : `AI request failed: ${String(error)}`;
-    return res.status(500).json({ items: [], message: msg });
+    return res.status(200).json({ reply: truncateReply(reply), message: 'OK' });
+  } catch (err) {
+    const message = err?.name === 'AbortError'
+      ? 'AI request timeout'
+      : `AI request failed: ${String(err).slice(0, 220)}`;
+    return res.status(500).json({ error: message });
   }
 }
 
-function safeJsonParse(text) {
+function validatePayload(payload) {
+  const message = String(payload.message ?? payload.prompt ?? '').trim();
+  if (!message) return { ok: false, error: 'Message is required' };
+  if (message.length > 4000) return { ok: false, error: 'Message is too long (max 4000 chars)' };
+
+  const allowedRoles = new Set(['system', 'user', 'assistant']);
+  const rawHistory = Array.isArray(payload.history) ? payload.history.slice(-10) : [];
+  const history = [];
+
+  for (const item of rawHistory) {
+    if (!item || typeof item !== 'object') continue;
+    if (!allowedRoles.has(item.role)) continue;
+    if (typeof item.content !== 'string') continue;
+    history.push({ role: item.role, content: item.content.slice(0, 2000) });
+  }
+
+  const historyTotalLength = history.reduce((sum, item) => sum + item.content.length, 0);
+  if (historyTotalLength > 12000) {
+    return { ok: false, error: 'History is too long' };
+  }
+
+  const systemPrompt = typeof payload.systemPrompt === 'string'
+    ? payload.systemPrompt.slice(0, 3000)
+    : '';
+
+  return {
+    ok: true,
+    value: { message, history, systemPrompt }
+  };
+}
+
+async function callOpenAI(mode, payload) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY is not set');
+
+  const { systemPrompt, userMessage, history } = buildMessages(mode, payload);
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    ...history,
+    { role: 'user', content: userMessage }
+  ];
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 28000);
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    signal: controller.signal,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+      max_tokens: 800,
+      temperature: 0.4,
+      messages
+    })
+  });
+
+  clearTimeout(timeout);
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`OpenAI API ${response.status}: ${err.slice(0, 300)}`);
+  }
+
+  const data = await response.json();
+  return data.choices?.[0]?.message?.content || '응답을 받지 못했어요.';
+}
+
+async function callClaude(mode, payload) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set');
+
+  const { systemPrompt, userMessage, history } = buildMessages(mode, payload);
+  const messages = [
+    ...history,
+    { role: 'user', content: userMessage }
+  ];
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 28000);
+
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    signal: controller.signal,
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01'
+    },
+    body: JSON.stringify({
+      model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-20250514',
+      max_tokens: 800,
+      system: systemPrompt,
+      messages
+    })
+  });
+
+  clearTimeout(timeout);
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`Claude API ${response.status}: ${err.slice(0, 300)}`);
+  }
+
+  const data = await response.json();
+  return data.content?.[0]?.text || '응답을 받지 못했어요.';
+}
+
+function buildMessages(mode, payload) {
+  const baseSystem = `당신은 PulseHome의 AI 플래너 어시스턴트입니다.
+사용자의 생산성과 목표 달성을 돕는 친근하고 동기부여가 되는 한국어 코치입니다.
+구체적이고 실행 가능한 짧은 답변을 주세요 (200자 이내).`;
+
+  if (mode === 'suggest') {
+    return {
+      systemPrompt: payload.systemPrompt || baseSystem,
+      userMessage: `다음 요청에 대해 실행 가능한 제안을 해주세요:\n${payload.message}`,
+      history: payload.history
+    };
+  }
+
+  return {
+    systemPrompt: payload.systemPrompt || baseSystem,
+    userMessage: payload.message,
+    history: payload.history
+  };
+}
+
+function truncateReply(text) {
+  const normalized = String(text || '').trim();
+  const maxLen = 700;
+  if (normalized.length <= maxLen) return normalized;
+  return `${normalized.slice(0, maxLen).trimEnd()}…`;
+}
+
+function safeJson(text) {
   try {
     return JSON.parse(text);
   } catch {
     return null;
   }
-}
-
-function readOutputText(data) {
-  if (typeof data.output_text === "string" && data.output_text.trim()) return data.output_text;
-
-  if (Array.isArray(data.output)) {
-    const parts = [];
-    for (const out of data.output) {
-      if (!Array.isArray(out.content)) continue;
-      for (const c of out.content) {
-        if (c.type === "output_text" && typeof c.text === "string") parts.push(c.text);
-      }
-    }
-    if (parts.length) return parts.join("\n");
-  }
-
-  return "";
-}
-
-function parseModelJson(text) {
-  const direct = safeJsonParse(text);
-  if (direct) return direct;
-
-  const first = text.indexOf("{");
-  const last = text.lastIndexOf("}");
-  if (first === -1 || last === -1 || last <= first) return null;
-  return safeJsonParse(text.slice(first, last + 1));
-}
-
-function normalizeDate(value) {
-  if (typeof value !== "string") return null;
-  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : null;
-}
-
-function normalizePriority(value) {
-  return ["high", "mid", "low"].includes(value) ? value : null;
-}
-
-function normalizeCategory(value) {
-  if (typeof value !== "string") return null;
-  return value.slice(0, 40);
-}
-
-function normalizeCell(value) {
-  const n = Number(value);
-  if (!Number.isInteger(n)) return null;
-  return n >= 1 && n <= 8 ? n : null;
-}
-
-function buildPrompts(mode, payload) {
-  const formatRules = [
-    "반드시 JSON 객체 하나만 반환하세요.",
-    "형식: {\"items\":[...],\"message\":\"...\"}",
-    "items 각 항목은 {\"text\":string,\"dueDate\"?:\"YYYY-MM-DD\",\"priority\"?:\"high|mid|low\",\"category\"?:string,\"mandalartCell\"?:1..8}",
-    "JSON 외 텍스트, 마크다운, 코드블록 금지",
-    "응답 언어는 한국어"
-  ].join("\n");
-
-  const systemPrompt = `너는 생산성 코치 AI다. 아래 규칙을 반드시 지켜라.\n${formatRules}`;
-
-  if (mode === "breakdown") {
-    const todoText = String(payload.todoText || "").trim();
-    return {
-      systemPrompt,
-      userPrompt: `모드: breakdown\n원본 투두: ${todoText}\n요청: 원본 투두를 실행 가능한 하위 투두 5~10개로 분해해라. items에만 넣어라.`
-    };
-  }
-
-  if (mode === "mandalart") {
-    const goal = String(payload.coreGoal || "").trim();
-    return {
-      systemPrompt,
-      userPrompt: `모드: mandalart\n중앙 목표: ${goal}\n요청:\n1) 1~8번 만다라트 칸 목표 8개 생성 (category는 \"mandalart_goal\", mandalartCell 필수)\n2) 각 칸 목표마다 실행 투두 1개씩 생성 (category는 \"mandala_todo\", mandalartCell 동일)\n총 16개 항목을 items에 반환해라.`
-    };
-  }
-
-  const todos = Array.isArray(payload.todos) ? payload.todos : [];
-  const serialized = JSON.stringify(
-    todos.map((t) => ({
-      text: t && t.text,
-      done: Boolean(t && t.done),
-      today: Boolean(t && t.today),
-      priority: t && t.priority,
-      dueDate: t && t.dueDate,
-      category: t && t.category
-    }))
-  );
-
-  return {
-    systemPrompt,
-    userPrompt: `모드: top3\n후보 투두(JSON): ${serialized}\n요청: 오늘 집중할 3개를 선택해 items에 넣어라. 반드시 후보의 text를 그대로 사용해라.`
-  };
 }

--- a/todo.html
+++ b/todo.html
@@ -103,6 +103,7 @@
     .btn {
       border: none; border-radius: var(--radius-sm);
       padding: 9px 14px; font-size: 13px; font-weight: 700;
+      min-height: 38px;
       cursor: pointer; transition: all .15s;
       display: inline-flex; align-items: center; gap: 6px;
     }
@@ -587,9 +588,83 @@
       .manda-grid { grid-template-columns: 1fr; }
     }
     @media (max-width: 640px) {
-      .nav-tab span.tab-label { display: none; }
-      .main { padding: 12px; }
-      .chat-modal { width: 100%; }
+      .topnav {
+        padding: 0 12px;
+        min-height: 56px;
+      }
+      .logo-text { font-size: 16px; margin-right: 8px; }
+      .nav-tabs {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 60;
+        background: rgba(255,255,255,0.96);
+        backdrop-filter: blur(12px);
+        border-top: 1px solid var(--line);
+        padding: 8px 10px calc(8px + env(safe-area-inset-bottom));
+        justify-content: space-between;
+        gap: 6px;
+      }
+      .nav-tab {
+        flex: 1;
+        justify-content: center;
+        padding: 10px 8px;
+        min-height: 44px;
+        border-radius: 12px;
+      }
+      .nav-tab .tab-icon { font-size: 16px; }
+      .nav-tab .tab-label { font-size: 12px; }
+
+      .main {
+        padding: 12px;
+        padding-bottom: calc(108px + env(safe-area-inset-bottom));
+      }
+
+      input[type="text"], input[type="date"], input[type="search"], select, textarea, button {
+        font-size: 16px;
+      }
+      .btn, .chip, .chat-send, .ai-chat-btn, .chat-close {
+        min-height: 44px;
+      }
+
+      .todo-add-card,
+      .sidebar-card,
+      .day-detail-card,
+      .focus-panel { padding: 12px; }
+      .todo-layout,
+      .routine-layout,
+      .stats-layout,
+      .sidebar,
+      .todo-list { gap: 10px; }
+      .todo-item,
+      .routine-item,
+      .manda-cell { padding: 10px; }
+
+      .modal-overlay {
+        align-items: stretch;
+        justify-content: stretch;
+        padding: 0;
+      }
+      .chat-modal {
+        width: 100%;
+        height: 100dvh;
+        border-radius: 0;
+        transform: translateY(32px);
+      }
+      .chat-messages {
+        padding: 12px;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      .ai-chat-btn {
+        position: fixed;
+        right: 12px;
+        bottom: calc(74px + env(safe-area-inset-bottom));
+        z-index: 70;
+        margin-left: 0;
+        padding: 10px 14px;
+      }
     }
   </style>
 </head>
@@ -1078,7 +1153,7 @@ function getTodos() {
   let list = [...state.todos];
   const { todoFilter, todoSort, todoSearch } = state.ui;
 
-  if (todoSearch) list = list.filter(t => t.title.toLowerCase().includes(todoSearch));
+  if (todoSearch) list = list.filter(t => String(t.title || '').toLowerCase().includes(String(todoSearch || '').toLowerCase()));
   if (todoFilter === 'active') list = list.filter(t => t.status === 'active');
   else if (todoFilter === 'done') list = list.filter(t => t.status === 'done');
   else list = list.filter(t => t.status !== 'archived');


### PR DESCRIPTION
### Motivation
- Make OpenAI/ChatGPT the default AI backend while keeping Claude available, and keep a serverless-friendly `/api/ai` proxy with timeouts. 
- Harden AI request handling to avoid malformed or overly-long payloads and improve UX when responses are long. 
- Improve mobile usability (bottom tab bar, touch targets, chat modal, floating AI button) so the app is comfortable on small screens. 

### Description
- `/api/ai.js`: default `AI_PROVIDER` fallback changed to `openai` and the handler now validates incoming payloads and modes (allowed `mode`: `chat` | `suggest`).
- Added `validatePayload` to enforce: required `message`, max message length (4000 chars), history limited to last 10 items with role whitelist (`system`/`user`/`assistant`) and a total history length cap (12000 chars); responses use `{ error: "..." }` on failure.
- Implemented `callOpenAI` / `callClaude` integrations (OpenAI default model `gpt-4o-mini`, override via `OPENAI_MODEL`) with `AbortController` timeouts preserved, and server-side reply truncation via `truncateReply` (max ~700 chars) to improve mobile UX.
- `todo.html` (CSS/JS): mobile (`max-width:640px`) layout overhauled: tabs moved to a fixed bottom bar with `env(safe-area-inset-bottom)` support, main receives bottom padding to avoid overlap, input/button font-size set to 16px and touch targets raised (min-height 44px), chat modal becomes near full-screen (`100dvh`, radius 0) with smoother scrolling, AI chat trigger becomes a floating button above the tab bar, and card/list spacing tightened for a cleaner mobile feel.
- Minor JS hardening in `todo.html`: search filtering made safer by lowercasing both the todo title and the search query (`String(...).toLowerCase()`), avoiding runtime errors for missing titles.

### Testing
- Static syntax check of the API: `node --check api/ai.js` (succeeded).
- Sanity parse/run of inlined app JS: extracted `<script>` from `todo.html` and ran `new Function(...)` to ensure no immediate runtime parse errors (succeeded).
- Local render capture: served `/workspace/man-todo` via `python3 -m http.server 4173` and captured a mobile screenshot using Playwright at 390×844 to validate layout (succeeded; artifact produced).
- Basic end-to-end file checks: committed changes and created PR summary; all automated checks executed in the patch environment passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa16ebf190833189a0e52c608d4556)